### PR TITLE
Fix: Error when switch to tab with taglist opened 

### DIFF
--- a/plugin/taglist.vim
+++ b/plugin/taglist.vim
@@ -4097,6 +4097,11 @@ endfunction
 " window. Used after entering a tab. If this is not done, then the folds
 " are not properly created for taglist windows displayed in multiple tabs.
 function! s:Tlist_Refresh_Folds()
+
+    if g:Tlist_Show_One_File
+      return
+    endif
+
     let winnum = bufwinnr(g:TagList_title)
     if winnum == -1
         return


### PR DESCRIPTION
When you have several tabs opened and you switch to one of them with taglist opened vim shows you the next error:

Error detected while processing function <SNR>29_Tlist_Refresh_Folds

With this commit this error is fixed.

This patch was written by Jan Larres(http://goo.gl/NqdsU).
