### PR TITLE
Added .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Pathogen
+doc/tags


### PR DESCRIPTION
Added .gitignore in order to prevent git from detecting changes when
tags file is created from :Helptags. Thus plugin can be used as a git
submodule much more easily (in conjunction with Pathogen).
