### PR TITLE
Update for Ctags 5.8

### DIFF
--- a/plugin/taglist.vim
+++ b/plugin/taglist.vim
@@ -2233,7 +2233,7 @@ function! s:Tlist_Process_File(filename, ftype)
     let s:tlist_{fidx}_valid = 1
 
     " Exuberant ctags arguments to generate a tag list
-    let ctags_args = ' -f - --format=2 --excmd=pattern --fields=nks '
+    let ctags_args = ' -f - --append=no --format=2 --excmd=pattern --fields=nks '
 
     " Form the ctags argument depending on the sort type
     if s:tlist_{fidx}_sort_type == 'name'


### PR DESCRIPTION
I get this error :

```
$ ctags -f - --format=2 --excmd=pattern --fields=nks --sort=no --language-force=java --java-types=pcifm "filename.java"
ctags: append mode is not compatible with tags to stdout

$ ctags --version
Exuberant Ctags 5.8, Copyright (C) 1996-2009 Darren Hiebert
```
